### PR TITLE
fix: Capitalize car colors in menu

### DIFF
--- a/api/src/routers/car.ts
+++ b/api/src/routers/car.ts
@@ -117,7 +117,7 @@ export const carRouter = router({
         make: z.string(),
         model: z.string(),
         year: z.string(),
-        color: z.string(),
+        color: z.string().toLowerCase(),
         photo: z.instanceof(File),
       });
 

--- a/app/routes/cars/utils.ts
+++ b/app/routes/cars/utils.ts
@@ -13,10 +13,6 @@ export const colors = [
   "Silver",
 ];
 
-export function capitalize(value: string) {
-  return value.charAt(0).toUpperCase() + value.slice(1);
-}
-
 export const years = Array.from({ length: 50 }, (_, i) =>
   String(new Date().getFullYear() + 1 - i)
 );

--- a/app/routes/cars/utils.ts
+++ b/app/routes/cars/utils.ts
@@ -1,16 +1,16 @@
 export const colors = [
-  "red",
-  "green",
-  "blue",
-  "purple",
-  "black",
-  "gray",
-  "pink",
-  "white",
-  "orange",
-  "tan",
-  "brown",
-  "silver",
+  "Red",
+  "Green",
+  "Blue",
+  "Purple",
+  "Black",
+  "Gray",
+  "Pink",
+  "White",
+  "Orange",
+  "Tan",
+  "Brown",
+  "Silver",
 ];
 
 export function capitalize(value: string) {

--- a/app/routes/ride/FindBeep.tsx
+++ b/app/routes/ride/FindBeep.tsx
@@ -124,7 +124,7 @@ export function MainFindBeepScreen(props: Props) {
       case Status.ON_THE_WAY:
         return "Beeper is on their way to get you.";
       case Status.HERE:
-        return `Beeper is here to pick you up in a ${beep.beeper.cars?.[0].color} ${beep.beeper.cars?.[0].make} ${beep.beeper.cars?.[0].model}`;
+        return `Beeper is here to pick you up in a ${beep.beeper.cars?.[0].color.toLowerCase()} ${beep.beeper.cars?.[0].make} ${beep.beeper.cars?.[0].model}`;
       case Status.IN_PROGRESS:
         return "You are currently in the car with your beeper.";
       default:

--- a/app/routes/ride/FindBeep.tsx
+++ b/app/routes/ride/FindBeep.tsx
@@ -124,7 +124,7 @@ export function MainFindBeepScreen(props: Props) {
       case Status.ON_THE_WAY:
         return "Beeper is on their way to get you.";
       case Status.HERE:
-        return `Beeper is here to pick you up in a ${beep.beeper.cars?.[0].color.toLowerCase()} ${beep.beeper.cars?.[0].make} ${beep.beeper.cars?.[0].model}`;
+        return `Beeper is here to pick you up in a ${beep.beeper.cars?.[0].color} ${beep.beeper.cars?.[0].make} ${beep.beeper.cars?.[0].model}`;
       case Status.IN_PROGRESS:
         return "You are currently in the car with your beeper.";
       default:


### PR DESCRIPTION
## 📝 Description

The dropdown menu for the color of a user's car currently has the first letter in lowercase as opposed to the other dropdowns, this changes it so that the color now has a capitalized first letter