### PR TITLE
fix: Sentry Postgres `@opentelemetry/instrumentation-pg` not working

### DIFF
--- a/api/src/utils/db.ts
+++ b/api/src/utils/db.ts
@@ -1,5 +1,5 @@
 import * as schema from '../../drizzle/schema';
-import { Pool } from "pg";
+const { Pool } = require("pg");
 import { drizzle } from "drizzle-orm/node-postgres";
 import { DB_HOST, DB_URL, ENVIRONMENT } from "./constants";
 


### PR DESCRIPTION
## 📝 Description

- Changing `import` to `require` for the `pg` import is enough to make bun work, thank goodness 🙏🏼 
- Finally resolves https://github.com/bnussman/beep/issues/106