### PR TITLE
fix: Local S3 bucket not getting created automatically when `docker compose up -d` is ran

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,11 @@ services:
     image: minio/minio
     ports:
       - "9000:9000"
+    healthcheck:
+      test: mc ready local
+      interval: 2s
+      timeout: 10s
+      retries: 5
     environment:
       MINIO_ACCESS_KEY: beep
       MINIO_SECRET_KEY: beepbeepbeep
@@ -26,7 +31,8 @@ services:
   bucket:
     image: minio/mc
     depends_on:
-      - s3
+      s3:
+        condition: service_healthy
     entrypoint: >
       /bin/sh -c "
       /usr/bin/mc alias set beep http://s3:9000 beep beepbeepbeep;


### PR DESCRIPTION
## 📝 Description

- Added a healthcheck to the `s3` (minio) service (based on info in https://github.com/minio/minio/issues/18389)
- Updated the `bucket` service (the service that creates the S3 bucket) to wait for the `s3` service to he alive before running the command that creates the S3 bucket


## How to reproduce the issue

> [!warning]
> This runs destructive docker commands. This is fine if you only use docker for beep on your system, but if you have other important docker stuff, don't do this. 

- Checkout the `main` branch
- Run `docker system prune --volumes`
- Run `docker compose up -d`
- Run `pnpm dev`
- Try signing up in the app or website or changing profile pic
- Observe `Bucket not found` error

## How to verify the fix

Follow the same steps above with this branch checked out. You should no longer see the Observe `Bucket not found` error.

