### PR TITLE
chore(app): Rework Native `Menu`s

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,10 +11,10 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@base-ui/react": "^1.5.0",
     "@expo/ui": "^56.0.16",
     "@gorhom/bottom-sheet": "5.2.9",
     "@react-native-async-storage/async-storage": "~2.2.0",
-    "@react-native-menu/menu": "^2.0.0",
     "@sentry/react-native": "7.11.0",
     "@tanstack/react-query": "^5.96.2",
     "@trpc/client": "^11.16.0",
@@ -41,8 +41,6 @@
     "react-hook-form": "^7.69.0",
     "react-native": "0.85.3",
     "react-native-gesture-handler": "~2.31.2",
-    "react-native-ios-context-menu": "^3.2.1",
-    "react-native-ios-utilities": "^5.2.0",
     "react-native-keyboard-controller": "1.21.6",
     "react-native-maps": "1.27.2",
     "react-native-purchases": "^9.1.0",
@@ -55,13 +53,12 @@
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",
     "tailwindcss": "^4.2.4",
-    "uniwind": "^1.6.3",
-    "zeego": "^3.0.6"
+    "uniwind": "^1.6.3"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
-    "@sentry/cli": "3.1.0",
     "@expo/metro-runtime": "56.0.14",
+    "@sentry/cli": "3.1.0",
     "@trpc/server": "^11.16.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "~19.2.0",

--- a/app/src/app/(tabs)/(beep)/_layout.tsx
+++ b/app/src/app/(tabs)/(beep)/_layout.tsx
@@ -1,6 +1,6 @@
 import { getNavigationMenuFromOptions } from "@/components/Menu.utils";
 import { UserMenu, useUserMenuOptions } from "@/components/UserMenu";
-import { isWeb } from "@/utils/constants";
+import { isAndroid, isWeb } from "@/utils/constants";
 import { Stack, useRouter } from "expo-router";
 import { CloseButton } from "heroui-native";
 
@@ -40,7 +40,7 @@ export default function Layout() {
       <Stack.Screen
         options={{
           headerTitle: "Premium",
-          presentation: "formSheet",
+          presentation: isAndroid ? undefined : "formSheet", // formSheet causes a crash on android (java.lang.NullPointerException com.swmansion.rnscreens.ScreenStackFragment.handleInsetsUpdateAndNotifyTransition)
           unstable_headerRightItems: (context) => [
             {
               type: "button",

--- a/app/src/app/(tabs)/(profile)/_layout.tsx
+++ b/app/src/app/(tabs)/(profile)/_layout.tsx
@@ -1,4 +1,5 @@
 import { AddCarButton } from "@/components/AddCarButton";
+import { Elipsis } from "@/components/Elipsis";
 import { Menu } from "@/components/Menu";
 import { getNavigationMenuFromOptions } from "@/components/Menu.utils";
 import { useProfileMenu } from "@/components/ProfileMenu";
@@ -24,7 +25,7 @@ export default function Layout() {
         options={{
           headerTitle: "Edit",
           unstable_headerRightItems: () => getNavigationMenuFromOptions(menu),
-          headerRight: () => <Menu trigger="..." options={menu} />,
+          headerRight: () => <Menu trigger={<Elipsis />} options={menu} />,
         }}
       />
       <Stack.Screen
@@ -90,3 +91,7 @@ export default function Layout() {
     </Stack>
   );
 }
+
+export const unstable_settings = {
+  initialRouteName: "profile/index",
+};

--- a/app/src/app/(tabs)/(profile)/profile/beeps/index.tsx
+++ b/app/src/app/(tabs)/(profile)/profile/beeps/index.tsx
@@ -34,6 +34,7 @@ export default function BeepsScreen() {
           }
           return page.page + 1;
         },
+        refetchOnMount: false,
       },
     ),
   );
@@ -84,7 +85,11 @@ export default function BeepsScreen() {
       contentContainerStyle={getContentContainerStyle(beeps?.length === 0)}
       renderItem={(data) => <Beep {...data} />}
       keyExtractor={(beep) => beep.id}
-      onEndReached={() => fetchNextPage()}
+      onEndReached={() => {
+        if (!isFetchingNextPage) {
+          fetchNextPage();
+        }
+      }}
       onEndReachedThreshold={0.1}
       ListFooterComponent={renderFooter()}
       contentInsetAdjustmentBehavior="automatic"

--- a/app/src/app/(tabs)/(profile)/profile/index.tsx
+++ b/app/src/app/(tabs)/(profile)/profile/index.tsx
@@ -8,7 +8,8 @@ import { Link, LinkProps } from "expo-router";
 import { useMutation } from "@tanstack/react-query";
 import { useTRPC } from "@/utils/trpc";
 import { Button } from "@/components/Button";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { useHeaderHeight } from "expo-router/react-navigation";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 interface LinkItem {
   icon: string | React.JSX.Element;
@@ -20,6 +21,8 @@ interface LinkItem {
 export default function EditProfileScreen() {
   const trpc = useTRPC();
   const { user } = useUser();
+  const headerHeight = useHeaderHeight();
+  const inset = useSafeAreaInsets();
 
   const links: LinkItem[] = [
     {
@@ -74,9 +77,15 @@ export default function EditProfileScreen() {
   );
 
   return (
-    <ScrollView contentInsetAdjustmentBehavior="automatic">
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      contentContainerStyle={{ paddingTop: inset.top + headerHeight }}
+    >
       <View
-        style={{ paddingHorizontal: 16, gap: user?.isEmailVerified ? 32 : 24 }}
+        style={{
+          paddingHorizontal: 16,
+          gap: user?.isEmailVerified ? 32 : 24,
+        }}
       >
         <Link
           href={{ pathname: "/user/[id]", params: { id: user?.id ?? "" } }}

--- a/app/src/app/(tabs)/(ride)/_layout.tsx
+++ b/app/src/app/(tabs)/(ride)/_layout.tsx
@@ -45,7 +45,7 @@ export default function Layout() {
 
             return {
               headerTitle: `${pickLocationTitleMap[params.type]} Location`,
-              presentation: "formSheet",
+              presentation: isAndroid ? undefined : "formSheet", // formSheet causes a crash on android (java.lang.NullPointerException com.swmansion.rnscreens.ScreenStackFragment.handleInsetsUpdateAndNotifyTransition)
               unstable_headerRightItems: (context) => [
                 {
                   type: "button",

--- a/app/src/app/(tabs)/_layout.tsx
+++ b/app/src/app/(tabs)/_layout.tsx
@@ -27,18 +27,18 @@ export default function Layout() {
     <NativeTabs minimizeBehavior="onScrollDown">
       <NativeTabs.Trigger name="(ride)">
         <NativeTabs.Trigger.Label>Ride</NativeTabs.Trigger.Label>
-        <NativeTabs.Trigger.Icon sf="car.fill" />
+        <NativeTabs.Trigger.Icon sf="car.fill" md="directions_car" />
       </NativeTabs.Trigger>
       <NativeTabs.Trigger name="(beep)">
         <NativeTabs.Trigger.Label>Beep</NativeTabs.Trigger.Label>
-        <NativeTabs.Trigger.Icon sf="steeringwheel" />
+        <NativeTabs.Trigger.Icon sf="steeringwheel" md="local_taxi" />
         <NativeTabs.Trigger.Badge hidden={!user?.isBeeping}>
           {queue?.length ? String(queue.length) : ""}
         </NativeTabs.Trigger.Badge>
       </NativeTabs.Trigger>
       <NativeTabs.Trigger name="(profile)">
         <NativeTabs.Trigger.Label>Profile</NativeTabs.Trigger.Label>
-        <NativeTabs.Trigger.Icon sf="person.fill" />
+        <NativeTabs.Trigger.Icon sf="person.fill" md="person" />
         {!user?.isEmailVerified && <NativeTabs.Trigger.Badge />}
         {/* <NativeTabs.Trigger.Icon src={{ uri: user?.photo ?? undefined, width: 24, height: 24,  }} /> */}
       </NativeTabs.Trigger>

--- a/app/src/components/Beep.tsx
+++ b/app/src/components/Beep.tsx
@@ -175,7 +175,7 @@ export function Beep({ item }: Props) {
           href={{ pathname: "/profile/beeps/[id]", params: { id: item.id } }}
           asChild
         >
-          <Link.Trigger withAppleZoom>
+          <Link.Trigger>
             <Card style={{ padding: 16, gap: 8 }} onLongPress={() => null}>
               <View
                 style={{ flexDirection: "row", alignItems: "center", gap: 8 }}

--- a/app/src/components/Menu.android.tsx
+++ b/app/src/components/Menu.android.tsx
@@ -2,28 +2,48 @@ import { MenuProps, Option } from "./Menu";
 import { MenuAction, MenuView } from "@expo/ui/community/menu";
 
 export function Menu(props: MenuProps) {
-  const getOption = (option: Option): MenuAction => {
+  const getOption = (option: Option): MenuAction | null => {
+    if (option.show !== undefined && !option.show) {
+      return null;
+    }
+
     if (option.options) {
       return {
         title: option.title,
-        subactions: option.options.map(getOption),
+        subactions: option.options.map(getOption).filter(Boolean) as MenuAction[],
       };
     }
 
     return {
       title: option.title,
       id: option.title,
+      titleColor: option.destructive ? "red" : undefined,
     };
+  };
+
+  const findOption = (options: Option[], title: string): Option | undefined => {
+    for (const option of options) {
+      if (option.title === title) {
+        return option;
+      }
+
+      if (option.options) {
+        const found = findOption(option.options, title);
+        if (found) {
+          return found;
+        }
+      }
+    }
+
+    return undefined;
   };
 
   return (
     <MenuView
-      actions={props.options.map(getOption)}
+      actions={props.options.map(getOption).filter(Boolean) as MenuAction[]}
       shouldOpenOnLongPress={props.activationMethod === "longPress"}
       onPressAction={(e) => {
-        const option = props.options.find(
-          (option) => option.title === e.nativeEvent.event,
-        );
+        const option = findOption(props.options, e.nativeEvent.event);
         option?.onClick?.();
       }}
     >

--- a/app/src/components/Menu.android.tsx
+++ b/app/src/components/Menu.android.tsx
@@ -1,0 +1,33 @@
+import { MenuProps, Option } from "./Menu";
+import { MenuAction, MenuView } from "@expo/ui/community/menu";
+
+export function Menu(props: MenuProps) {
+  const getOption = (option: Option): MenuAction => {
+    if (option.options) {
+      return {
+        title: option.title,
+        subactions: option.options.map(getOption),
+      };
+    }
+
+    return {
+      title: option.title,
+      id: option.title,
+    };
+  };
+
+  return (
+    <MenuView
+      actions={props.options.map(getOption)}
+      shouldOpenOnLongPress={props.activationMethod === "longPress"}
+      onPressAction={(e) => {
+        const option = props.options.find(
+          (option) => option.title === e.nativeEvent.event,
+        );
+        option?.onClick?.();
+      }}
+    >
+      {props.trigger}
+    </MenuView>
+  );
+}

--- a/app/src/components/Menu.ios.tsx
+++ b/app/src/components/Menu.ios.tsx
@@ -3,21 +3,22 @@ import {
   Menu as ExpoUIMenu,
   Button,
   RNHostView,
+  ContextMenu,
 } from "@expo/ui/swift-ui";
 import { MenuProps, Option } from "./Menu";
 import type { JSX } from "react/jsx-runtime";
-import { disabled } from "@expo/ui/swift-ui/modifiers";
+import { disabled, fixedSize } from "@expo/ui/swift-ui/modifiers";
 
 export function Menu(props: MenuProps) {
-  const renderOption = (option: Option) => {
+  const renderMenuOption = (option: Option) => {
     if (option.show !== undefined && !option.show) {
       return null;
     }
 
     if (option.options) {
       return (
-        <ExpoUIMenu label={undefined}>
-          {option.options.map(renderOption)}
+        <ExpoUIMenu label={option.title} systemImage={option.sfIcon}>
+          {option.options.map(renderMenuOption)}
         </ExpoUIMenu>
       );
     }
@@ -33,6 +34,23 @@ export function Menu(props: MenuProps) {
     );
   };
 
+  if (props.activationMethod === "longPress") {
+    return (
+      <Host matchContents modifiers={[fixedSize()]}>
+        <ContextMenu>
+          <ContextMenu.Trigger>
+            <RNHostView matchContents>
+              {props.trigger as JSX.Element}
+            </RNHostView>
+          </ContextMenu.Trigger>
+          <ContextMenu.Items>
+            {props.options.map(renderMenuOption)}
+          </ContextMenu.Items>
+        </ContextMenu>
+      </Host>
+    );
+  }
+
   return (
     <Host matchContents>
       <ExpoUIMenu
@@ -40,7 +58,7 @@ export function Menu(props: MenuProps) {
           <RNHostView matchContents>{props.trigger as JSX.Element}</RNHostView>
         }
       >
-        {props.options.map(renderOption)}
+        {props.options.map(renderMenuOption)}
       </ExpoUIMenu>
     </Host>
   );

--- a/app/src/components/Menu.ios.tsx
+++ b/app/src/components/Menu.ios.tsx
@@ -1,0 +1,47 @@
+import {
+  Host,
+  Menu as ExpoUIMenu,
+  Button,
+  RNHostView,
+} from "@expo/ui/swift-ui";
+import { MenuProps, Option } from "./Menu";
+import type { JSX } from "react/jsx-runtime";
+import { disabled } from "@expo/ui/swift-ui/modifiers";
+
+export function Menu(props: MenuProps) {
+  const renderOption = (option: Option) => {
+    if (option.show !== undefined && !option.show) {
+      return null;
+    }
+
+    if (option.options) {
+      return (
+        <ExpoUIMenu label={undefined}>
+          {option.options.map(renderOption)}
+        </ExpoUIMenu>
+      );
+    }
+
+    return (
+      <Button
+        systemImage={option.sfIcon}
+        label={option.title}
+        onPress={option.onClick}
+        modifiers={option.disabled ? [disabled()] : []}
+        role={option.destructive ? "destructive" : undefined}
+      />
+    );
+  };
+
+  return (
+    <Host matchContents>
+      <ExpoUIMenu
+        label={
+          <RNHostView matchContents>{props.trigger as JSX.Element}</RNHostView>
+        }
+      >
+        {props.options.map(renderOption)}
+      </ExpoUIMenu>
+    </Host>
+  );
+}

--- a/app/src/components/Menu.ios.tsx
+++ b/app/src/components/Menu.ios.tsx
@@ -17,7 +17,11 @@ export function Menu(props: MenuProps) {
 
     if (option.options) {
       return (
-        <ExpoUIMenu label={option.title} systemImage={option.sfIcon}>
+        <ExpoUIMenu
+          key={option.title}
+          label={option.title}
+          systemImage={option.sfIcon}
+        >
           {option.options.map(renderMenuOption)}
         </ExpoUIMenu>
       );
@@ -25,6 +29,7 @@ export function Menu(props: MenuProps) {
 
     return (
       <Button
+        key={option.title}
         systemImage={option.sfIcon}
         label={option.title}
         onPress={option.onClick}

--- a/app/src/components/Menu.tsx
+++ b/app/src/components/Menu.tsx
@@ -1,6 +1,7 @@
 import { SFSymbolIcon } from "expo-router/unstable-native-tabs";
 import { Menu as BaseMenu } from "@base-ui/react/menu";
 import { ContextMenu } from "@base-ui/react/context-menu";
+import { cx } from "tailwind-variants";
 
 export interface Option {
   /**
@@ -78,12 +79,12 @@ export const Menu = (props: MenuProps) => {
     if (option.options) {
       return (
         <MenuComponent.SubmenuRoot key={option.title}>
-          <MenuComponent.SubmenuTrigger className="text-foreground">
+          <MenuComponent.SubmenuTrigger className={itemClasses}>
             {option.title}
           </MenuComponent.SubmenuTrigger>
           <MenuComponent.Portal>
             <MenuComponent.Positioner>
-              <MenuComponent.Popup>
+              <MenuComponent.Popup className={popupClasses}>
                 {option.options.map(renderOption)}
               </MenuComponent.Popup>
             </MenuComponent.Positioner>
@@ -95,7 +96,7 @@ export const Menu = (props: MenuProps) => {
     return (
       <MenuComponent.Item
         onClick={option.onClick}
-        className="text-foreground"
+        className={cx(itemClasses, { "text-red-400": option.destructive })}
         disabled={option.disabled}
         key={option.title}
       >
@@ -106,12 +107,12 @@ export const Menu = (props: MenuProps) => {
 
   return (
     <MenuComponent.Root>
-      <MenuComponent.Trigger aria-label={props.label}>
+      <MenuComponent.Trigger className="*:w-full" aria-label={props.label}>
         {props.trigger}
       </MenuComponent.Trigger>
       <MenuComponent.Portal>
         <MenuComponent.Positioner>
-          <MenuComponent.Popup>
+          <MenuComponent.Popup className={popupClasses}>
             {props.options.map(renderOption)}
           </MenuComponent.Popup>
         </MenuComponent.Positioner>
@@ -119,3 +120,8 @@ export const Menu = (props: MenuProps) => {
     </MenuComponent.Root>
   );
 };
+
+const popupClasses =
+  "bg-surface border-border border rounded-xl p-2 shadow min-w-[200px] max-h-[var(--available-height)] overflow-y-auto";
+const itemClasses =
+  "text-foreground p-2 cursor-pointer hover:bg-surface-hover rounded-xl";

--- a/app/src/components/Menu.tsx
+++ b/app/src/components/Menu.tsx
@@ -1,13 +1,17 @@
-import { Menu as HeroMenu, SubMenu } from "heroui-native";
-import { Text } from "@/components/Text";
 import { SFSymbolIcon } from "expo-router/unstable-native-tabs";
-import { Pressable, useColorScheme } from "react-native";
+import { Menu as BaseMenu } from "@base-ui/react/menu";
+import { ContextMenu } from "@base-ui/react/context-menu";
 
 export interface Option {
   /**
    * The text content of the option
    */
   title: string;
+  /**
+   * An SF Symbol name to show alongside the option. Only works on iOS.
+   *
+   * @platform ios
+   */
   sfIcon?: Extract<SFSymbolIcon["sf"], string>;
   /**
    * Called when the option is chosen/clicked/pressed
@@ -59,7 +63,8 @@ export interface MenuProps {
 }
 
 export const Menu = (props: MenuProps) => {
-  const colorScheme = useColorScheme();
+  const MenuComponent =
+    props.activationMethod === "longPress" ? ContextMenu : BaseMenu;
 
   if (props.disabled) {
     return props.trigger;
@@ -72,36 +77,43 @@ export const Menu = (props: MenuProps) => {
 
     if (option.options) {
       return (
-        <SubMenu key={option.title}>
-          <SubMenu.Trigger textValue="Focus">
-            <SubMenu.TriggerIndicator />
-            <Text className="flex-1 text-base font-medium text-foreground">
-              {option.title}
-            </Text>
-          </SubMenu.Trigger>
-          <SubMenu.Content>{option.options.map(renderOption)}</SubMenu.Content>
-        </SubMenu>
+        <MenuComponent.SubmenuRoot key={option.title}>
+          <MenuComponent.SubmenuTrigger className="text-foreground">
+            {option.title}
+          </MenuComponent.SubmenuTrigger>
+          <MenuComponent.Portal>
+            <MenuComponent.Positioner>
+              <MenuComponent.Popup>
+                {option.options.map(renderOption)}
+              </MenuComponent.Popup>
+            </MenuComponent.Positioner>
+          </MenuComponent.Portal>
+        </MenuComponent.SubmenuRoot>
       );
     }
 
     return (
-      <HeroMenu.Item key={option.title} onPress={option.onClick}>
-        <HeroMenu.ItemTitle>{option.title}</HeroMenu.ItemTitle>
-      </HeroMenu.Item>
+      <MenuComponent.Item
+        onClick={option.onClick}
+        className="text-foreground"
+        disabled={option.disabled}
+        key={option.title}
+      >
+        {option.title}
+      </MenuComponent.Item>
     );
   };
 
   return (
-    <HeroMenu isOpen>
-      <HeroMenu.Trigger asChild>
-        <Pressable>{props.trigger}</Pressable>
-      </HeroMenu.Trigger>
-      <HeroMenu.Portal>
-        <HeroMenu.Overlay />
-        <HeroMenu.Content presentation="popover" width={240}>
-          {props.options.map(renderOption)}
-        </HeroMenu.Content>
-      </HeroMenu.Portal>
-    </HeroMenu>
+    <MenuComponent.Root>
+      <MenuComponent.Trigger>{props.trigger}</MenuComponent.Trigger>
+      <MenuComponent.Portal>
+        <MenuComponent.Positioner>
+          <MenuComponent.Popup>
+            {props.options.map(renderOption)}
+          </MenuComponent.Popup>
+        </MenuComponent.Positioner>
+      </MenuComponent.Portal>
+    </MenuComponent.Root>
   );
 };

--- a/app/src/components/Menu.tsx
+++ b/app/src/components/Menu.tsx
@@ -1,8 +1,7 @@
-import * as DropdownMenu from "zeego/dropdown-menu";
-import * as ContextMenu from "zeego/context-menu";
-import { isWeb } from "@/utils/constants";
+import { Menu as HeroMenu, SubMenu } from "heroui-native";
+import { Text } from "@/components/Text";
 import { SFSymbolIcon } from "expo-router/unstable-native-tabs";
-import { useColorScheme } from "react-native";
+import { Pressable, useColorScheme } from "react-native";
 
 export interface Option {
   /**
@@ -66,9 +65,6 @@ export const Menu = (props: MenuProps) => {
     return props.trigger;
   }
 
-  const Component =
-    props.activationMethod === "longPress" ? ContextMenu : DropdownMenu;
-
   const renderOption = (option: Option) => {
     if (option.show !== undefined && !option.show) {
       return null;
@@ -76,80 +72,36 @@ export const Menu = (props: MenuProps) => {
 
     if (option.options) {
       return (
-        <Component.Sub key={option.title}>
-          <Component.SubTrigger key={option.title}>
-            <Component.ItemIcon
-              ios={{ name: option.sfIcon }}
-            ></Component.ItemIcon>
-            <Component.ItemTitle
-              className={
-                isWeb
-                  ? colorScheme === "dark"
-                    ? "text-white"
-                    : "text-black"
-                  : undefined
-              }
-            >
+        <SubMenu key={option.title}>
+          <SubMenu.Trigger textValue="Focus">
+            <SubMenu.TriggerIndicator />
+            <Text className="flex-1 text-base font-medium text-foreground">
               {option.title}
-            </Component.ItemTitle>
-          </Component.SubTrigger>
-          <Component.SubContent>
-            {option.options.map(renderOption)}
-          </Component.SubContent>
-        </Component.Sub>
+            </Text>
+          </SubMenu.Trigger>
+          <SubMenu.Content>{option.options.map(renderOption)}</SubMenu.Content>
+        </SubMenu>
       );
     }
 
-    const C =
-      option.checked !== undefined ? Component.CheckboxItem : Component.Item;
-
-    const moreProps =
-      option.checked !== undefined
-        ? {
-            onValueChange: option.onClick,
-          }
-        : {};
-
     return (
-      <C
-        value={option.checked ? "on" : "off"}
-        key={option.title}
-        destructive={isWeb ? undefined : option.destructive}
-        disabled={option.disabled}
-        onSelect={option.onClick}
-        {...moreProps}
-      >
-        <Component.ItemIcon ios={{ name: option.sfIcon }}></Component.ItemIcon>
-        <Component.ItemTitle
-          className={
-            isWeb
-              ? colorScheme === "dark"
-                ? "text-white"
-                : "text-black"
-              : undefined
-          }
-        >
-          {option.title}
-        </Component.ItemTitle>
-      </C>
+      <HeroMenu.Item key={option.title} onPress={option.onClick}>
+        <HeroMenu.ItemTitle>{option.title}</HeroMenu.ItemTitle>
+      </HeroMenu.Item>
     );
   };
 
   return (
-    <Component.Root>
-      <Component.Trigger
-        aria-label={props.label}
-        className={
-          isWeb
-            ? colorScheme === "dark"
-              ? "text-white *:w-full"
-              : "text-black *:w-full"
-            : undefined
-        }
-      >
-        {props.trigger}
-      </Component.Trigger>
-      <Component.Content>{props.options.map(renderOption)}</Component.Content>
-    </Component.Root>
+    <HeroMenu isOpen>
+      <HeroMenu.Trigger asChild>
+        <Pressable>{props.trigger}</Pressable>
+      </HeroMenu.Trigger>
+      <HeroMenu.Portal>
+        <HeroMenu.Overlay />
+        <HeroMenu.Content presentation="popover" width={240}>
+          {props.options.map(renderOption)}
+        </HeroMenu.Content>
+      </HeroMenu.Portal>
+    </HeroMenu>
   );
 };

--- a/app/src/components/Menu.tsx
+++ b/app/src/components/Menu.tsx
@@ -106,7 +106,9 @@ export const Menu = (props: MenuProps) => {
 
   return (
     <MenuComponent.Root>
-      <MenuComponent.Trigger>{props.trigger}</MenuComponent.Trigger>
+      <MenuComponent.Trigger aria-label={props.label}>
+        {props.trigger}
+      </MenuComponent.Trigger>
       <MenuComponent.Portal>
         <MenuComponent.Positioner>
           <MenuComponent.Popup>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
 
   app:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.5.0
+        version: 1.5.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@expo/ui':
         specifier: ^56.0.16
         version: 56.0.16(@babel/core@7.29.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(expo@56.0.9)(react-dom@19.2.3(react@19.2.3))(react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -86,9 +89,6 @@ importers:
       '@react-native-async-storage/async-storage':
         specifier: ~2.2.0
         version: 2.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))
-      '@react-native-menu/menu':
-        specifier: ^2.0.0
-        version: 2.0.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       '@sentry/react-native':
         specifier: 7.11.0
         version: 7.11.0(expo@56.0.9)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -167,12 +167,6 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.31.2
         version: 2.31.2(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
-      react-native-ios-context-menu:
-        specifier: ^3.2.1
-        version: 3.2.1(react-native-ios-utilities@5.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
-      react-native-ios-utilities:
-        specifier: ^5.2.0
-        version: 5.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-keyboard-controller:
         specifier: 1.21.6
         version: 1.21.6(react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -212,9 +206,6 @@ importers:
       uniwind:
         specifier: ^1.6.3
         version: 1.6.3(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(tailwindcss@4.2.4)
-      zeego:
-        specifier: ^3.0.6
-        version: 3.0.6(@react-native-menu/menu@2.0.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-native-ios-context-menu@3.2.1(react-native-ios-utilities@5.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-ios-utilities@5.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.0
@@ -755,6 +746,10 @@ packages:
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
@@ -777,8 +772,32 @@ packages:
   '@banksnussman/photon@0.0.4':
     resolution: {integrity: sha512-YUVVCRQgpQJ+ACXhdwb5j288uNNoXtSHd1Q9G8amq85ugq7bjQiWKdYOwZSqJufGM25amyde8NwUodF4acSbRw==}
 
-  '@dominicstop/ts-event-emitter@1.1.0':
-    resolution: {integrity: sha512-CcxmJIvUb1vsFheuGGVSQf4KdPZC44XolpUT34+vlal+LyQoBUOn31pjFET5M9ctOxEpt8xa0M3/2M7uUiAoJw==}
+  '@base-ui/react@1.5.0':
+    resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.2.9':
+    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@drizzle-team/brocli@0.11.0':
     resolution: {integrity: sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg==}
@@ -1351,20 +1370,20 @@ packages:
     resolution: {integrity: sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==}
     hasBin: true
 
-  '@floating-ui/core@1.7.3':
-    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
-  '@floating-ui/dom@1.7.4':
-    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
-  '@floating-ui/react-dom@2.1.6':
-    resolution: {integrity: sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==}
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/utils@0.2.10':
-    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@fontsource/poppins@5.2.7':
     resolution: {integrity: sha512-6uQyPmseo4FgI97WIhA4yWRlNaoLk4vSDK/PyRwdqqZb5zAEuc+Kunt8JTMcsHYUEGYBtN15SNkMajMdqUSUmg==}
@@ -2009,19 +2028,6 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
-  '@radix-ui/react-arrow@1.1.7':
-    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
@@ -2042,19 +2048,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-context-menu@2.2.16':
-    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.1.2':
@@ -2101,19 +2094,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-dropdown-menu@2.1.16':
-    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -2143,32 +2123,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-menu@2.1.16':
-    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-popper@1.2.8':
-    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-portal@1.1.9':
@@ -2290,27 +2244,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-use-rect@1.1.1':
-    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-size@1.1.1':
-    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/rect@1.1.1':
-    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
-
   '@react-native-async-storage/async-storage@2.2.0':
     resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
     peerDependencies:
@@ -2321,12 +2254,6 @@ packages:
     peerDependencies:
       react: '>=16'
       react-native: '>=0.57'
-
-  '@react-native-menu/menu@2.0.0':
-    resolution: {integrity: sha512-hb8Mirw6aKPGONhgo52IiNpwHtISVrgCT3rMdFX1qS7eOFNzOcQh8d2UDnaH5zVpxN+QuvWtaaiRMGFpIjzdtA==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
 
   '@react-native/assets-registry@0.85.3':
     resolution: {integrity: sha512-u9ZiYP23vA2IFtdFQFmetzSmk6SM0xgKIoiOsr1hXNHjHaLhOm+/Ph1ud57wX6+Dbwdzx8coJgnzSKL3W21PCg==}
@@ -5717,19 +5644,6 @@ packages:
       react: '*'
       react-native: '*'
 
-  react-native-ios-context-menu@3.2.1:
-    resolution: {integrity: sha512-OBQbb3I/VUx2wQgz4cqN614kt3nJ+qx5wxEdtGN1Aj4nYYL1orp7VLFkV6axof6DgOyv0YD6af2RUTok6a2xDQ==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
-      react-native-ios-utilities: '*'
-
-  react-native-ios-utilities@5.2.0:
-    resolution: {integrity: sha512-RTw1Gk8rQhBL43+U80I+Nu8T7mLTNkj5RaG8vTs3ETEDqphS3L0Mrzk79RX0Jmm64HMad70GXHctXFlW1n0V8w==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
-
   react-native-is-edge-to-edge@1.2.1:
     resolution: {integrity: sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==}
     peerDependencies:
@@ -6068,10 +5982,6 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-
-  sf-symbols-typescript@2.1.0:
-    resolution: {integrity: sha512-ezT7gu/SHTPIOEEoG6TF+O0m5eewl0ZDAO4AtdBi5HjsrUI6JdCG17+Q8+aKp0heM06wZKApRCn5olNbs0Wb/A==}
-    engines: {node: '>=10'}
 
   sf-symbols-typescript@2.2.0:
     resolution: {integrity: sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw==}
@@ -6740,15 +6650,6 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  zeego@3.0.6:
-    resolution: {integrity: sha512-vg0GCMPYg6or/J91bwRnUpIYwz7QnhkyeKOdd3FjvICg+Gzq2D5QhD8k5RUSv1B+048LpNmNYdLm8qJVIbBONw==}
-    peerDependencies:
-      '@react-native-menu/menu': 1.2.2
-      react: '*'
-      react-native: '*'
-      react-native-ios-context-menu: 3.1.0
-      react-native-ios-utilities: 5.1.2
-
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -7232,6 +7133,8 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -7268,7 +7171,28 @@ snapshots:
     dependencies:
       openapi-fetch: 0.14.0
 
-  '@dominicstop/ts-event-emitter@1.1.0': {}
+  '@base-ui/react@1.5.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.2.9(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@base-ui/utils@0.2.9(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@drizzle-team/brocli@0.11.0': {}
 
@@ -7911,22 +7835,22 @@ snapshots:
       chalk: 4.1.2
       js-yaml: 4.1.1
 
-  '@floating-ui/core@1.7.3':
+  '@floating-ui/core@1.7.5':
     dependencies:
-      '@floating-ui/utils': 0.2.10
+      '@floating-ui/utils': 0.2.11
 
-  '@floating-ui/dom@1.7.4':
+  '@floating-ui/dom@1.7.6':
     dependencies:
-      '@floating-ui/core': 1.7.3
-      '@floating-ui/utils': 0.2.10
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
 
-  '@floating-ui/react-dom@2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@floating-ui/dom': 1.7.4
+      '@floating-ui/dom': 1.7.6
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@floating-ui/utils@0.2.10': {}
+  '@floating-ui/utils@0.2.11': {}
 
   '@fontsource/poppins@5.2.7': {}
 
@@ -8691,15 +8615,6 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
   '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
@@ -8717,20 +8632,6 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.14
-
-  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.3)':
     dependencies:
@@ -8779,21 +8680,6 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -8817,50 +8703,6 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.14
-
-  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.3)
-      aria-hidden: 1.2.6
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-remove-scroll: 2.7.1(@types/react@19.2.14)(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.3)
-      '@radix-ui/rect': 1.1.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -8965,33 +8807,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.3)':
-    dependencies:
-      '@radix-ui/rect': 1.1.1
-      react: 19.2.3
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.3)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
-      react: 19.2.3
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@radix-ui/rect@1.1.1': {}
-
   '@react-native-async-storage/async-storage@2.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))':
     dependencies:
       merge-options: 3.0.4
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
 
   '@react-native-masked-view/masked-view@0.3.2(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
-
-  '@react-native-menu/menu@2.0.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
@@ -9712,7 +9533,7 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -12549,18 +12370,6 @@ snapshots:
       react: 19.2.3
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
 
-  react-native-ios-context-menu@3.2.1(react-native-ios-utilities@5.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
-    dependencies:
-      '@dominicstop/ts-event-emitter': 1.1.0
-      react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
-      react-native-ios-utilities: 5.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
-
-  react-native-ios-utilities@5.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
-    dependencies:
-      react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
-
   react-native-is-edge-to-edge@1.2.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -12785,7 +12594,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
 
   regexpu-core@6.4.0:
     dependencies:
@@ -12962,8 +12771,6 @@ snapshots:
   setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
-
-  sf-symbols-typescript@2.1.0: {}
 
   sf-symbols-typescript@2.2.0: {}
 
@@ -13335,6 +13142,10 @@ snapshots:
     dependencies:
       react: 19.2.0
 
+  use-sync-external-store@1.6.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
@@ -13498,21 +13309,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  zeego@3.0.6(@react-native-menu/menu@2.0.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-native-ios-context-menu@3.2.1(react-native-ios-utilities@5.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-ios-utilities@5.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
-    dependencies:
-      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@react-native-menu/menu': 2.0.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
-      react-native-ios-context-menu: 3.2.1(react-native-ios-utilities@5.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
-      react-native-ios-utilities: 5.2.0(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
-      sf-symbols-typescript: 2.1.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react-dom
 
   zod@3.25.76: {}
 

--- a/test/tests/beep.spec.ts
+++ b/test/tests/beep.spec.ts
@@ -49,7 +49,7 @@ test("a beep can happen between a rider and driver", async ({ browser }) => {
   await expect(riderPage.getByText("Call")).toBeVisible();
   await expect(riderPage.getByText("Text")).toBeVisible();
 
-  await riderPage.getByText("Pay").click();
+  await riderPage.getByText("Pay").click({ force: true });
   await expect(riderPage.getByText("Venmo")).toBeVisible();
   // await expect(riderPage.getByText("Share Venmo")).toBeVisible(); removed for now
 


### PR DESCRIPTION
The goal is to use `@expo/ui`'s native iOS and Android menus and drop the dependency on `react-native-ios-context-menu`, `react-native-ios-utilities`, `@react-native-menu/menu`, and `zeego`

For web, I wanted to use `heroui-native`'s Menu, but it does not work very well at all... May have to explore other options