### PR TITLE
chore: Rework ETA calculation architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: 11.10.0
           run_install: false
       - uses: actions/setup-node@v6
         with:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: 11.10.0
           run_install: false
       - uses: actions/setup-node@v6
         with:
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: 11.10.0
           run_install: false
       - uses: actions/setup-node@v6
         with:
@@ -57,7 +57,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: 11.10.0
           run_install: false
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: 11.10.0
           run_install: false
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,5 +35,7 @@ jobs:
         if: always()
         with:
           name: playwright-report
-          path: test/playwright-report/
+          path: |
+            test/playwright-report/
+            test/test-results/
           retention-days: 10

--- a/api/drizzle/20260711235627_loose_meggan/migration.sql
+++ b/api/drizzle/20260711235627_loose_meggan/migration.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "beep" ADD COLUMN "eta" timestamp with time zone;--> statement-breakpoint
-ALTER TABLE "beep" ADD COLUMN "eta_updated_at" timestamp with time zone;

--- a/api/drizzle/20260711235627_loose_meggan/migration.sql
+++ b/api/drizzle/20260711235627_loose_meggan/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "beep" ADD COLUMN "eta" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "beep" ADD COLUMN "eta_updated_at" timestamp with time zone;

--- a/api/drizzle/20260711235627_loose_meggan/snapshot.json
+++ b/api/drizzle/20260711235627_loose_meggan/snapshot.json
@@ -1,0 +1,1746 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "94d2d187-af26-4b3f-ae67-d719b70f5bbc",
+  "prevIds": [
+    "b74ab5c6-74df-4845-8746-e8e967e42867"
+  ],
+  "ddl": [
+    {
+      "values": [
+        "canceled",
+        "denied",
+        "waiting",
+        "accepted",
+        "on_the_way",
+        "here",
+        "in_progress",
+        "complete"
+      ],
+      "name": "beep_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "top_of_beeper_list_1_hour",
+        "top_of_beeper_list_2_hours",
+        "top_of_beeper_list_3_hours"
+      ],
+      "name": "payment_product",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "play_store",
+        "app_store"
+      ],
+      "name": "payment_store",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "sha256",
+        "bcrypt"
+      ],
+      "name": "user_password_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "user",
+        "admin"
+      ],
+      "name": "user_role",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "beep",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "car",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "feedback",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "forgot_password",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "payment",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "rating",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "report",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "token",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "verify_email",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "beeper_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rider_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "origin",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "destination",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "group_size",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "end",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "beep_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'waiting'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rider_live_activity_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rider_live_activity_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "eta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "eta_updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "make",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "model",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "color",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "photo",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "year",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "default",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feedback"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feedback"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feedback"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feedback"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "forgot_password"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "forgot_password"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "time",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "forgot_password"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "payment"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "payment"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "store_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "payment"
+    },
+    {
+      "type": "payment_product",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "product_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "payment"
+    },
+    {
+      "type": "numeric",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "price",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "payment"
+    },
+    {
+      "type": "payment_store",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "store",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "payment"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "payment"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "payment"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "rating"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rater_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "rating"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rated_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "rating"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stars",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "rating"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "rating"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "timestamp",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "rating"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "beep_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "rating"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reporter_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reported_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "handled_by_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "timestamp",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "handled",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "beep_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rating_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "token"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tokenid",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "token"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "token"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "username",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "phone",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "venmo",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cashapp",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "user_password_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'bcrypt'",
+      "generated": null,
+      "identity": null,
+      "name": "password_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "is_beeping",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "is_email_verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "is_student",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "4",
+      "generated": null,
+      "identity": null,
+      "name": "group_rate",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "3",
+      "generated": null,
+      "identity": null,
+      "name": "singles_rate",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "4",
+      "generated": null,
+      "identity": null,
+      "name": "capacity",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "queue_size",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "numeric",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rating",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "user_role",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'user'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "push_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "photo",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "geometry",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verify_email"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verify_email"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "time",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verify_email"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verify_email"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "beeper_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "beeper_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "beeper_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "rider_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "beeper_id_rider_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "rider_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "rider_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "start",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "start_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "beeper_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "beep_beeper_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "rider_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "beep_rider_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "beep"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "car_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "car"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "feedback_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "feedback"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "forgot_password_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "forgot_password"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "payment_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "payment"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "rater_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "rating_rater_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "rating"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "rated_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "rating_rated_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "rating"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "beep_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "beep",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "rating_beep_id_beep_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "rating"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "reporter_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "report_reporter_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "reported_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "report_reported_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "handled_by_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "report_handled_by_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "beep_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "beep",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "report_beep_id_beep_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "rating_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "rating",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "report_rating_id_rating_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "report"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "token_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "token"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "verify_email_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "verify_email"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "beep_pkey",
+      "schema": "public",
+      "table": "beep",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "car_pkey",
+      "schema": "public",
+      "table": "car",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "feedback_pkey",
+      "schema": "public",
+      "table": "feedback",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "forgot_password_pkey",
+      "schema": "public",
+      "table": "forgot_password",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "payment_pkey",
+      "schema": "public",
+      "table": "payment",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "rating_pkey",
+      "schema": "public",
+      "table": "rating",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "report_pkey",
+      "schema": "public",
+      "table": "report",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "token_pkey",
+      "schema": "public",
+      "table": "token",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_pkey",
+      "schema": "public",
+      "table": "user",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verify_email_pkey",
+      "schema": "public",
+      "table": "verify_email",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "rater_id",
+        "beep_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "rating_beep_id_rater_id_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "rating"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "username"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_username_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "user"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_email_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "user"
+    }
+  ],
+  "renames": []
+}

--- a/api/drizzle/20260712165130_flawless_famine/migration.sql
+++ b/api/drizzle/20260712165130_flawless_famine/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "beep" ADD COLUMN "pick_up_eta" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "beep" ADD COLUMN "pick_up_eta_updated_at" timestamp with time zone;

--- a/api/drizzle/20260712165130_flawless_famine/snapshot.json
+++ b/api/drizzle/20260712165130_flawless_famine/snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "8",
   "dialect": "postgres",
-  "id": "94d2d187-af26-4b3f-ae67-d719b70f5bbc",
+  "id": "1bff52fb-1496-4220-812f-8a033b1f607c",
   "prevIds": [
     "b74ab5c6-74df-4845-8746-e8e967e42867"
   ],
@@ -269,7 +269,7 @@
       "default": null,
       "generated": null,
       "identity": null,
-      "name": "eta",
+      "name": "pick_up_eta",
       "entityType": "columns",
       "schema": "public",
       "table": "beep"
@@ -282,7 +282,7 @@
       "default": null,
       "generated": null,
       "identity": null,
-      "name": "eta_updated_at",
+      "name": "pick_up_eta_updated_at",
       "entityType": "columns",
       "schema": "public",
       "table": "beep"

--- a/api/drizzle/schema.ts
+++ b/api/drizzle/schema.ts
@@ -189,6 +189,8 @@ export const beep = pgTable(
     rider_live_activity_id: varchar("rider_live_activity_id", {
       length: 255,
     }),
+    eta: timestamp("eta", { withTimezone: true, mode: "date" }),
+    eta_updated_at: timestamp("eta_updated_at", { withTimezone: true, mode: "date" }),
   },
   (table) => [
     index("beeper_id_idx").using("btree", table.beeper_id),

--- a/api/drizzle/schema.ts
+++ b/api/drizzle/schema.ts
@@ -189,8 +189,8 @@ export const beep = pgTable(
     rider_live_activity_id: varchar("rider_live_activity_id", {
       length: 255,
     }),
-    eta: timestamp("eta", { withTimezone: true, mode: "date" }),
-    eta_updated_at: timestamp("eta_updated_at", { withTimezone: true, mode: "date" }),
+    pick_up_eta: timestamp("pick_up_eta", { withTimezone: true, mode: "date" }),
+    pick_up_eta_updated_at: timestamp("pick_up_eta_updated_at", { withTimezone: true, mode: "date" }),
   },
   (table) => [
     index("beeper_id_idx").using("btree", table.beeper_id),

--- a/api/src/logic/beep.ts
+++ b/api/src/logic/beep.ts
@@ -375,7 +375,11 @@ export async function updateEta(beeperId: string, location: { latitude: number; 
 
   const eta = new Date(Date.now() + durationMs);
 
-  await db.update(beep).set({ pick_up_eta: eta, pick_up_eta_updated_at: new Date() }).where(eq(beep.id, currentBeep.id));
+  const values = { pick_up_eta: eta, pick_up_eta_updated_at: new Date() };
+
+  pubSub.publish("ride", currentBeep.rider_id, { ride: values });
+
+  await db.update(beep).set(values).where(eq(beep.id, currentBeep.id));
 }
 
 export async function getETA(locations: { latitude: number;  longitude: number }[]) {

--- a/api/src/logic/beep.ts
+++ b/api/src/logic/beep.ts
@@ -331,6 +331,11 @@ export async function updateEta(beeperId: string, location: { latitude: number; 
   // If the beeper does not have an in-progress beep, we don't need to update the ETA
   if (!currentBeep) return;
 
+  // If the beep status isn't "on_the_way", don't do anything
+  if (currentBeep.status !== 'on_the_way') {
+    return;
+  }
+
   // If the beep's eta has been updated within the last 30 seconds, we don't need to update it again
   if (currentBeep.eta_updated_at && (Date.now() - currentBeep.eta_updated_at.getTime()) < 30000) {
     return;

--- a/api/src/logic/beep.ts
+++ b/api/src/logic/beep.ts
@@ -347,33 +347,10 @@ export async function updateEta(beeperId: string, location: { latitude: number; 
     return;
   }
 
-  const { data, error } = await osrm.GET(
-    "/route/{version}/{profile}/{coordinates}",
-    {
-      baseUrl: OSRM_BASE_URL,
-      params: {
-        path: {
-          profile: "driving",
-          coordinates: `${location.longitude},${location.latitude};${currentBeep.rider.location.longitude},${currentBeep.rider.location.latitude}`,
-          version: "v1",
-        },
-      },
-    },
-  );
+  const eta = await getETA([location, currentBeep.rider.location]);
 
-  if (error) {
-    return;
-  }
-
-  const route = data.routes[0];
-
-  if (!route) {
-    return;
-  }
-
-  const durationMs = route.duration * 1000;
-
-  const eta = new Date(Date.now() + durationMs);
+  // If we can't calculate an ETA for whatever reason, don't do anything
+  if (!eta) return;
 
   const values = { pick_up_eta: eta, pick_up_eta_updated_at: new Date() };
 
@@ -386,6 +363,7 @@ export async function getETA(locations: { latitude: number;  longitude: number }
   const { data, error } = await osrm.GET(
     "/route/{version}/{profile}/{coordinates}",
     {
+      signal: AbortSignal.timeout(5_000),
       baseUrl: OSRM_BASE_URL,
       params: {
         path: {

--- a/api/src/logic/beep.ts
+++ b/api/src/logic/beep.ts
@@ -337,7 +337,7 @@ export async function updateEta(beeperId: string, location: { latitude: number; 
   }
 
   // If the beep's eta has been updated within the last 30 seconds, we don't need to update it again
-  if (currentBeep.eta_updated_at && (Date.now() - currentBeep.eta_updated_at.getTime()) < 30000) {
+  if (currentBeep.pick_up_eta_updated_at && (Date.now() - currentBeep.pick_up_eta_updated_at.getTime()) < 30000) {
     return;
   }
 
@@ -375,7 +375,7 @@ export async function updateEta(beeperId: string, location: { latitude: number; 
 
   const eta = new Date(Date.now() + durationMs);
 
-  await db.update(beep).set({ eta, eta_updated_at: new Date() }).where(eq(beep.id, currentBeep.id));
+  await db.update(beep).set({ pick_up_eta: eta, pick_up_eta_updated_at: new Date() }).where(eq(beep.id, currentBeep.id));
 }
 
 export async function getETA(locations: { latitude: number;  longitude: number }[]) {

--- a/api/src/logic/beep.ts
+++ b/api/src/logic/beep.ts
@@ -359,33 +359,37 @@ export async function updateEta(beeperId: string, location: { latitude: number; 
   await db.update(beep).set(values).where(eq(beep.id, currentBeep.id));
 }
 
-export async function getETA(locations: { latitude: number;  longitude: number }[]) {
-  const { data, error } = await osrm.GET(
-    "/route/{version}/{profile}/{coordinates}",
-    {
-      signal: AbortSignal.timeout(5_000),
-      baseUrl: OSRM_BASE_URL,
-      params: {
-        path: {
-          profile: "driving",
-          coordinates: locations.map((location) => `${location.longitude},${location.latitude}`).join(';'),
-          version: "v1",
+export async function getETA(locations: { latitude: number; longitude: number }[]) {
+  try {
+    const { data, error } = await osrm.GET(
+      "/route/{version}/{profile}/{coordinates}",
+      {
+        signal: AbortSignal.timeout(5_000),
+        baseUrl: OSRM_BASE_URL,
+        params: {
+          path: {
+            profile: "driving",
+            coordinates: locations.map((location) => `${location.longitude},${location.latitude}`).join(';'),
+            version: "v1",
+          },
         },
       },
-    },
-  );
+    );
 
-  if (error) {
+    if (error) {
+      return null;
+    }
+
+    const route = data.routes[0];
+
+    if (!route) {
+      return null;
+    }
+
+    const durationMs = route.duration * 1000;
+
+    return new Date(Date.now() + durationMs);
+  } catch (error) {
     return null;
   }
-
-  const route = data.routes[0];
-
-  if (!route) {
-    return null;
-  }
-
-  const durationMs = route.duration * 1000;
-
-  return new Date(Date.now() + durationMs);
 }

--- a/api/src/logic/beep.ts
+++ b/api/src/logic/beep.ts
@@ -364,7 +364,7 @@ export async function getETA(locations: { latitude: number; longitude: number }[
     const { data, error } = await osrm.GET(
       "/route/{version}/{profile}/{coordinates}",
       {
-        signal: AbortSignal.timeout(5_000),
+        signal: AbortSignal.timeout(4_000),
         baseUrl: OSRM_BASE_URL,
         params: {
           path: {

--- a/api/src/logic/beep.ts
+++ b/api/src/logic/beep.ts
@@ -5,6 +5,8 @@ import { beep } from "../../drizzle/schema";
 import { pubSub, User } from "../utils/pubsub";
 import { sendNotification } from "../utils/notifications";
 import { updateLiveActivity } from "../utils/live-activities";
+import { OSRM_BASE_URL } from "../utils/constants";
+import { osrm } from "@banksnussman/osrm";
 
 type Beep = typeof beep.$inferSelect;
 
@@ -315,4 +317,58 @@ export async function getInProgressBeepsCount() {
 export async function publishBeepsCount() {
   const count = await getBeepsCount();
   pubSub.publish("beepsCount", count);
+}
+
+export async function updateEta(beeperId: string, location: { latitude: number; longitude: number }) {
+  const currentBeep = await db.query.beep.findFirst({
+    where: { AND: [{ beeper_id: beeperId }, inProgressBeepNew] },
+    orderBy: { start: 'asc' },
+    with: {
+      rider: { columns: { location: true } }
+    }
+  })
+
+  // If the beeper does not have an in-progress beep, we don't need to update the ETA
+  if (!currentBeep) return;
+
+  // If the beep's eta has been updated within the last 30 seconds, we don't need to update it again
+  if (currentBeep.eta_updated_at && (Date.now() - currentBeep.eta_updated_at.getTime()) < 30000) {
+    return;
+  }
+
+  // If the rider doesn't have a location, we can't calculate an ETA
+  // @todo we could fallback to using the pick up location
+  if (!currentBeep.rider.location) {
+    return;
+  }
+
+  const { data, error } = await osrm.GET(
+    "/route/{version}/{profile}/{coordinates}",
+    {
+      baseUrl: OSRM_BASE_URL,
+      params: {
+        path: {
+          profile: "driving",
+          coordinates: `${location.longitude},${location.latitude};${currentBeep.rider.location.longitude},${currentBeep.rider.location.latitude}`,
+          version: "v1",
+        },
+      },
+    },
+  );
+
+  if (error) {
+    return;
+  }
+
+  const route = data.routes[0];
+
+  if (!route) {
+    return;
+  }
+
+  const durationMs = route.duration * 1000;
+
+  const eta = new Date(Date.now() + durationMs);
+
+  await db.update(beep).set({ eta, eta_updated_at: new Date() }).where(eq(beep.id, currentBeep.id));
 }

--- a/api/src/logic/beep.ts
+++ b/api/src/logic/beep.ts
@@ -372,3 +372,33 @@ export async function updateEta(beeperId: string, location: { latitude: number; 
 
   await db.update(beep).set({ eta, eta_updated_at: new Date() }).where(eq(beep.id, currentBeep.id));
 }
+
+export async function getETA(locations: { latitude: number;  longitude: number }[]) {
+  const { data, error } = await osrm.GET(
+    "/route/{version}/{profile}/{coordinates}",
+    {
+      baseUrl: OSRM_BASE_URL,
+      params: {
+        path: {
+          profile: "driving",
+          coordinates: locations.map((location) => `${location.longitude},${location.latitude}`).join(';'),
+          version: "v1",
+        },
+      },
+    },
+  );
+
+  if (error) {
+    return null;
+  }
+
+  const route = data.routes[0];
+
+  if (!route) {
+    return null;
+  }
+
+  const durationMs = route.duration * 1000;
+
+  return new Date(Date.now() + durationMs);
+}

--- a/api/src/routers/beeper.ts
+++ b/api/src/routers/beeper.ts
@@ -126,8 +126,8 @@ export const beeperRouter = router({
         const eta = await getETA([ctx.user.location, queueEntry.rider.location]);
 
         if (eta) {
-          values.eta = eta;
-          values.eta_updated_at = new Date();
+          values.pick_up_eta = eta;
+          values.pick_up_eta_updated_at = new Date();
         }
       }
 

--- a/api/src/routers/beeper.ts
+++ b/api/src/routers/beeper.ts
@@ -10,6 +10,7 @@ import { zAsyncIterable } from "../utils/zAsyncIterable";
 import {
   getBeeperQueue,
   getDerivedRiderFields,
+  getETA,
   getIsInProgressBeep,
   getQueueSize,
   sendBeepUpdateNotificationToRider,
@@ -114,16 +115,25 @@ export const beeperRouter = router({
         input.data.status === "canceled";
       const isQueueSizeChanging = isStartingBeep || isEndingBeep;
 
-      const values = {
+      const values: Partial<typeof beep.$inferInsert> = {
         status: input.data.status,
         ...(isEndingBeep && {
           end: new Date(),
         }),
       };
 
+      if (input.data.status === 'on_the_way' && ctx.user.location && queueEntry.rider.location) {
+        const eta = await getETA([ctx.user.location, queueEntry.rider.location]);
+
+        if (eta) {
+          values.eta = eta;
+          values.eta_updated_at = new Date();
+        }
+      }
+
       await db.update(beep).set(values).where(eq(beep.id, queueEntry.id));
 
-      queueEntry.status = input.data.status;
+      Object.assign(queueEntry, values);
 
       if (isQueueSizeChanging) {
         await db

--- a/api/src/routers/rider.ts
+++ b/api/src/routers/rider.ts
@@ -158,6 +158,8 @@ export const riderRouter = router({
         end: null,
         rider_live_activity_token: null,
         rider_live_activity_id: null,
+        eta: null,
+        eta_updated_at: null
       } as const;
 
       const currentRide = await db.query.beep.findFirst({

--- a/api/src/routers/rider.ts
+++ b/api/src/routers/rider.ts
@@ -158,8 +158,8 @@ export const riderRouter = router({
         end: null,
         rider_live_activity_token: null,
         rider_live_activity_id: null,
-        eta: null,
-        eta_updated_at: null
+        pick_up_eta: null,
+        pick_up_eta_updated_at: null
       } as const;
 
       const currentRide = await db.query.beep.findFirst({

--- a/api/src/routers/rider.ts
+++ b/api/src/routers/rider.ts
@@ -228,8 +228,8 @@ export const riderRouter = router({
     .input(z.string().optional())
     .output(
       zAsyncIterable({
-        yield: rideResponseSchema.nullable(),
-        return: rideResponseSchema.nullable(),
+        yield: rideResponseSchema.partial().nullable(),
+        return: rideResponseSchema.partial().nullable(),
       }),
     )
     .subscription(async function* ({ ctx, signal, input }) {

--- a/api/src/routers/user.ts
+++ b/api/src/routers/user.ts
@@ -11,7 +11,7 @@ import { email } from "../utils/email";
 import { sendNotification } from "../utils/notifications";
 import { pubSub } from "../utils/pubsub";
 import { isAlpha, isMobilePhone } from "validator";
-import { inProgressBeep, inProgressBeepNew, updateEta } from "../logic/beep";
+import { inProgressBeep, updateEta } from "../logic/beep";
 import { userSchema } from "../schemas/user";
 import { zAsyncIterable } from "../utils/zAsyncIterable";
 import { getActivePayments } from "../logic/payments";

--- a/api/src/routers/user.ts
+++ b/api/src/routers/user.ts
@@ -259,6 +259,8 @@ export const userRouter = router({
           location: u[0].location,
         };
 
+        updateEta(input.userId, data.location);
+
         pubSub.publish("locations", data);
       }
 

--- a/api/src/routers/user.ts
+++ b/api/src/routers/user.ts
@@ -11,7 +11,7 @@ import { email } from "../utils/email";
 import { sendNotification } from "../utils/notifications";
 import { pubSub } from "../utils/pubsub";
 import { isAlpha, isMobilePhone } from "validator";
-import { inProgressBeep } from "../logic/beep";
+import { inProgressBeep, inProgressBeepNew, updateEta } from "../logic/beep";
 import { userSchema } from "../schemas/user";
 import { zAsyncIterable } from "../utils/zAsyncIterable";
 import { getActivePayments } from "../logic/payments";
@@ -177,6 +177,8 @@ export const userRouter = router({
           id: ctx.user.id,
           location: input.location,
         };
+
+        updateEta(ctx.user.id, input.location);
 
         pubSub.publish("locations", data);
       }

--- a/api/src/schemas/beep.ts
+++ b/api/src/schemas/beep.ts
@@ -21,7 +21,8 @@ export const rideResponseSchema = z.object({
   }),
   position: z.number(),
   queue: z.array(z.object({ status: z.enum(beepStatuses) })),
-  riders_waiting: z.number()
+  riders_waiting: z.number(),
+  pick_up_eta: z.union([z.string(), z.date()]).nullable(),
 });
 
 export const queueResponseSchema = z.array(

--- a/api/src/utils/pubsub.ts
+++ b/api/src/utils/pubsub.ts
@@ -10,7 +10,7 @@ type Queue = z.infer<typeof queueResponseSchema>;
 
 type PubSubChannels = {
   user: [userId: string, payload: { user: User }];
-  ride: [userId: string, payload: { ride: Ride }];
+  ride: [userId: string, payload: { ride: Partial<Ride> }];
   queue: [userId: string, payload: { queue: Queue }];
   locations: [
     payload: { id: string; location: { latitude: number; longitude: number } },

--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@base-ui/react": "^1.5.0",
     "@expo/ui": "^57.0.4",
+    "luxon": "^3.7.2",
     "@gorhom/bottom-sheet": "5.2.9",
     "@react-native-async-storage/async-storage": "~2.2.0",
     "@sentry/react-native": "7.11.0",
@@ -63,6 +64,7 @@
     "@expo/dom-webview": "^57.0.0",
     "@sentry/cli": "3.1.0",
     "@trpc/server": "^11.16.0",
+    "@types/luxon": "^3.7.1",
     "@types/react": "19.2.14",
     "@types/react-dom": "~19.2.0",
     "babel-plugin-react-compiler": "^1.0.0",

--- a/app/src/app/(tabs)/(beep)/beep/index.tsx
+++ b/app/src/app/(tabs)/(beep)/beep/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import * as Location from "expo-location";
 import { useNavigation } from "expo-router/react-navigation";
-import { Alert, View, Switch, ActivityIndicator } from "react-native";
+import { Alert, View } from "react-native";
 import { Input } from "@/components/Input";
 import { Label } from "@/components/Label";
 import { Text } from "@/components/Text";
@@ -11,12 +11,11 @@ import { Controller, useForm } from "react-hook-form";
 import { useQuery } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { getTimeRemainingString } from "@/components/CountDown";
-import { isAndroid, isIOS, isWeb } from "@/utils/constants";
+import { isAndroid, isWeb } from "@/utils/constants";
 import { useUser } from "@/utils/useUser";
 import { PremiumBanner } from "@/components/PremiumBanner";
 import { Beep } from "@/components/beeper/Beep";
-import { Link, SplashScreen, Stack, useRouter } from "expo-router";
+import { Link, SplashScreen, useRouter } from "expo-router";
 import {
   startLocationTracking,
   stopLocationTracking,
@@ -30,6 +29,7 @@ import { Description, FieldError, TextField } from "heroui-native";
 import { Menu, Option } from "@/components/Menu";
 import { Elipsis } from "@/components/Elipsis";
 import { getNavigationMenuFromOptions } from "@/components/Menu.utils";
+import { getTimeRemaining } from "@/utils/date";
 
 export default function StartBeepingScreen() {
   const trpc = useTRPC();
@@ -189,7 +189,7 @@ export default function StartBeepingScreen() {
                       onPress: () => {
                         Alert.alert(
                           "You are premium!",
-                          `Your premium status will expire in ${getTimeRemainingString(new Date(payments[0].expires))}`,
+                          `Your premium status will expire ${getTimeRemaining(payments[0].expires)}`,
                         );
                       },
                     },
@@ -222,7 +222,7 @@ export default function StartBeepingScreen() {
                   onPress={() =>
                     Alert.alert(
                       "You are premium!",
-                      `Your premium status will expire in ${getTimeRemainingString(new Date(payments[0].expires))}`,
+                      `Your premium status will expire ${getTimeRemaining(payments[0].expires)}`,
                     )
                   }
                 >

--- a/app/src/app/(tabs)/(beep,ride,profile)/premium.tsx
+++ b/app/src/app/(tabs)/(beep,ride,profile)/premium.tsx
@@ -109,7 +109,7 @@ function Package({ p, disabled }: { p: PurchasesPackage; disabled: boolean }) {
       <Text weight="bold">{p.identifier}</Text>
       {payment && (
         <Text size="sm">
-          Expires in <Countdown date={new Date(payment.expires)} />
+          Expires in <Countdown date={payment.expires} />
         </Text>
       )}
       <View style={{ flexGrow: 1 }} />

--- a/app/src/app/(tabs)/(ride)/ride/index.tsx
+++ b/app/src/app/(tabs)/(ride)/ride/index.tsx
@@ -39,7 +39,17 @@ export default function MainFindBeepScreen() {
             trpc.rider.getLastBeepToRate.pathFilter(),
           );
         }
-        queryClient.setQueryData(trpc.rider.currentRide.queryKey(), data);
+        queryClient.setQueryData(trpc.rider.currentRide.queryKey(), (prev) => {
+          if (data === null) {
+            return null;
+          }
+          if (!prev) {
+            return data as typeof beep;
+          }
+          const updatedBeep = { ...prev };
+          Object.assign(updatedBeep, data);
+          return updatedBeep;
+        });
       },
       enabled: Boolean(beep),
     }),

--- a/app/src/components/CountDown.tsx
+++ b/app/src/components/CountDown.tsx
@@ -1,12 +1,8 @@
+import { getTimeRemaining } from "@/utils/date";
 import { useState, useEffect } from "react";
-import { DateTime } from "luxon";
 
 interface Props {
   date: string;
-}
-
-function getTimeRemaining(date: string) {
-  return DateTime.fromISO(date).toRelative();
 }
 
 export const Countdown = (props: Props) => {

--- a/app/src/components/CountDown.tsx
+++ b/app/src/components/CountDown.tsx
@@ -1,69 +1,34 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
+import { DateTime } from "luxon";
 
-export const calculateTimeRemaining = (targetDate: Date) => {
-  const now = new Date().getTime();
-  const targetTime = new Date(targetDate).getTime();
-  const timeDifference = targetTime - now;
-
-  if (timeDifference <= 0) {
-    return null;
-  }
-
-  const hours = Math.floor(
-    (timeDifference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60),
-  );
-  const minutes = Math.floor((timeDifference % (1000 * 60 * 60)) / (1000 * 60));
-  const seconds = Math.floor((timeDifference % (1000 * 60)) / 1000);
-
-  return { hours, minutes, seconds };
-};
-
-export function getTimeRemainingString(date: Date) {
-  const reminaing = calculateTimeRemaining(date);
-
-  if (!reminaing) {
-    return "";
-  }
-
-  const { hours, minutes, seconds } = reminaing;
-
-  const parts = [];
-
-  if (hours) {
-    parts.push(`${hours} ${hours === 1 ? "hour" : "hours"}`);
-  }
-
-  if (minutes) {
-    parts.push(`${minutes} ${minutes === 1 ? "minute" : "minutes"}`);
-  }
-
-  if (seconds) {
-    parts.push(`${seconds} ${seconds === 1 ? "second" : "seconds"}`);
-  }
-
-  return parts.join(" ");
+interface Props {
+  date: string;
 }
 
-export const Countdown = ({ date }: { date: Date }) => {
+function getTimeRemaining(date: string) {
+  return DateTime.fromISO(date).toRelative();
+}
+
+export const Countdown = (props: Props) => {
   const [timeRemaining, setTimeRemaining] = useState(
-    calculateTimeRemaining(date),
+    getTimeRemaining(props.date)
   );
 
   useEffect(() => {
+    setTimeRemaining(getTimeRemaining(props.date));
+
     const interval = setInterval(() => {
-      setTimeRemaining(calculateTimeRemaining(date));
+      setTimeRemaining(getTimeRemaining(props.date));
     }, 1000);
 
     return () => {
       clearInterval(interval);
     };
-  }, [date]);
+  }, [props.date]);
 
   if (timeRemaining === null) {
-    return null;
+    return "N/A";
   }
 
-  const { hours, minutes, seconds } = timeRemaining;
-
-  return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+  return timeRemaining;
 };

--- a/app/src/components/ETA.tsx
+++ b/app/src/components/ETA.tsx
@@ -14,7 +14,7 @@ export function ETA(props: Props) {
 
       return (
         <Text>
-          <Countdown date={props.eta} /> ({pickUpAt})
+          Pick up <Countdown date={props.eta} /> ({pickUpAt})
         </Text>
       );
     }

--- a/app/src/components/ETA.tsx
+++ b/app/src/components/ETA.tsx
@@ -1,5 +1,6 @@
 import { Text } from "@/components/Text";
 import { View } from "react-native";
+import { Countdown } from "./CountDown";
 
 interface Props {
   eta: string | null;
@@ -9,7 +10,13 @@ export function ETA(props: Props) {
 
   const renderBody = () => {
     if (props.eta) {
-      return `Pick up ${getRelativeTimeInMinutes(props.eta)} (at ${new Date(props.eta).toLocaleTimeString([], { timeStyle: 'short' })})`;
+      const pickUpAt = new Date(props.eta).toLocaleTimeString([], { timeStyle: 'short' });
+
+      return (
+        <Text>
+          <Countdown date={props.eta} /> ({pickUpAt})
+        </Text>
+      );
     }
 
     return "N/A";
@@ -21,22 +28,4 @@ export function ETA(props: Props) {
       <Text>{renderBody()}</Text>
     </View>
   );
-}
-
-function getRelativeTimeInMinutes(isoString: string) {
-  const targetDate = new Date(isoString);
-  const now = new Date();
-
-  // Calculate the difference in milliseconds
-  const diffInMs = targetDate.getTime() - now.getTime();
-
-  // Convert milliseconds to total minutes
-  const diffInMinutes = Math.round(diffInMs / 1000 / 60);
-
-  // Return future or past string format
-  if (diffInMinutes >= 0) {
-    return `in ${diffInMinutes} min`;
-  } else {
-    return `${Math.abs(diffInMinutes)} min ago`;
-  }
 }

--- a/app/src/components/ETA.tsx
+++ b/app/src/components/ETA.tsx
@@ -1,50 +1,15 @@
 import { Text } from "@/components/Text";
-import { useTRPC } from "@/utils/trpc";
-import { useLocation } from "@/utils/location";
-import { ActivityIndicator, View } from "react-native";
-import { skipToken, useQuery } from "@tanstack/react-query";
-
-interface Location {
-  latitude: number;
-  longitude: number;
-}
+import { View } from "react-native";
 
 interface Props {
-  beeperLocation: Location | null | undefined;
+  eta: string | null;
 }
 
 export function ETA(props: Props) {
-  const trpc = useTRPC();
-  const { beeperLocation } = props;
-  const { location } = useLocation();
-
-  const { data, error, isPending } = useQuery(
-    trpc.location.getETA.queryOptions(
-      beeperLocation && location
-        ? {
-            start: `${beeperLocation.longitude},${beeperLocation.latitude}`,
-            end: `${location.coords.longitude},${location.coords.latitude}`,
-          }
-        : skipToken,
-    ),
-  );
-
-  const renderContent = () => {
-    if (isPending) {
-      return <ActivityIndicator />;
-    }
-
-    if (error) {
-      return <Text>{error.message}</Text>;
-    }
-
-    return <Text>{data}</Text>;
-  };
-
   return (
     <View>
       <Text weight="800">ETA</Text>
-      {renderContent()}
+      <Text>{props.eta ?? "N/A"}</Text>
     </View>
   );
 }

--- a/app/src/components/ETA.tsx
+++ b/app/src/components/ETA.tsx
@@ -6,10 +6,37 @@ interface Props {
 }
 
 export function ETA(props: Props) {
+
+  const renderBody = () => {
+    if (props.eta) {
+      return `Pick up ${getRelativeTimeInMinutes(props.eta)} (at ${new Date(props.eta).toLocaleTimeString([], { timeStyle: 'short' })})`;
+    }
+
+    return "N/A";
+  };
+
   return (
     <View>
       <Text weight="800">ETA</Text>
-      <Text>{props.eta ?? "N/A"}</Text>
+      <Text>{renderBody()}</Text>
     </View>
   );
+}
+
+function getRelativeTimeInMinutes(isoString: string) {
+  const targetDate = new Date(isoString);
+  const now = new Date();
+
+  // Calculate the difference in milliseconds
+  const diffInMs = targetDate.getTime() - now.getTime();
+
+  // Convert milliseconds to total minutes
+  const diffInMinutes = Math.round(diffInMs / 1000 / 60);
+
+  // Return future or past string format
+  if (diffInMinutes >= 0) {
+    return `in ${diffInMinutes} min`;
+  } else {
+    return `${Math.abs(diffInMinutes)} min ago`;
+  }
 }

--- a/app/src/components/PremiumBanner.tsx
+++ b/app/src/components/PremiumBanner.tsx
@@ -22,7 +22,7 @@ export function PremiumBanner() {
             You are premium! 👑
           </Text>
           <Text>
-            Expires in <Countdown date={new Date(payment.expires)} />
+            Expires in <Countdown date={payment.expires} />
           </Text>
         </>
       ) : (

--- a/app/src/components/RideDetails.tsx
+++ b/app/src/components/RideDetails.tsx
@@ -111,7 +111,7 @@ export function RideDetails(props: Props) {
           <Text>{getCurrentStatusMessage(beep)}</Text>
         )}
       </View>
-      {beep.status === "on_the_way" && beep.pick_up_eta && (
+      {beep.status === "on_the_way" && (
         <ETA eta={beep.pick_up_eta} />
       )}
       {car && (

--- a/app/src/components/RideDetails.tsx
+++ b/app/src/components/RideDetails.tsx
@@ -111,8 +111,8 @@ export function RideDetails(props: Props) {
           <Text>{getCurrentStatusMessage(beep)}</Text>
         )}
       </View>
-      {beep.status === "on_the_way" && (
-        <ETA beeperLocation={props.beepersLocation} />
+      {beep.status === "on_the_way" && beep.pick_up_eta && (
+        <ETA eta={beep.pick_up_eta} />
       )}
       {car && (
         <View>

--- a/app/src/utils/date.ts
+++ b/app/src/utils/date.ts
@@ -1,0 +1,5 @@
+import { DateTime } from "luxon";
+
+export function getTimeRemaining(date: string) {
+  return DateTime.fromISO(date).toRelative();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       heroui-native:
         specifier: ^1.0.2
         version: 1.0.2(cde50ce2f1144584753bcb793ea03420)
+      luxon:
+        specifier: ^3.7.2
+        version: 3.7.2
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -231,6 +234,9 @@ importers:
       '@trpc/server':
         specifier: ^11.16.0
         version: 11.16.0(typescript@6.0.3)
+      '@types/luxon':
+        specifier: ^3.7.1
+        version: 3.7.1
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? 'github' : 'html',
+  reporter: process.env.CI ? [['html'], ['github']] : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -21,7 +21,8 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:8081/',
-
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     permissions: ['geolocation'],

--- a/website/src/routes/admin/beeps/$beepId.tsx
+++ b/website/src/routes/admin/beeps/$beepId.tsx
@@ -55,10 +55,10 @@ function Beep() {
     trpc.location.getRoute.queryOptions(
       beep
         ? {
-            origin: beep.origin,
-            destination: beep.destination,
-            bias: beeper?.location,
-          }
+          origin: beep.origin,
+          destination: beep.destination,
+          bias: beeper?.location,
+        }
         : skipToken,
       {
         placeholderData: keepPreviousData,
@@ -149,33 +149,33 @@ function Beep() {
       title: "Duration",
       content: beep.end
         ? Interval.fromDateTimes(
-            DateTime.fromISO(beep.start),
-            DateTime.fromISO(beep.end),
-          )
-            .toDuration()
-            .rescale()
-            .set({ milliseconds: 0 })
-            .rescale()
-            .toHuman()
+          DateTime.fromISO(beep.start),
+          DateTime.fromISO(beep.end),
+        )
+          .toDuration()
+          .rescale()
+          .set({ milliseconds: 0 })
+          .rescale()
+          .toHuman()
         : "N/A",
     },
     {
-      title: "ETA",
-      content: beep.eta ? (
-        <Typography>
-          {DateTime.fromISO(beep.eta).toRelative()}
-        </Typography>
-      ) : (
-        <Typography>N/A</Typography>
-      )
-    },
-    {
-      title: "ETA updated",
-      content: beep.eta_updated_at ? (
-        <Typography>
-          {DateTime.fromISO(beep.eta_updated_at).toRelative()}
-        </Typography>
-      ) : (
+      title: "Pick Up ETA",
+      content: beep.pick_up_eta ? (() => {
+        const date = DateTime.fromISO(beep.pick_up_eta!);
+        const isInThePast = date < DateTime.now();
+
+        return (
+          <Stack>
+            <Typography>
+              {isInThePast ? date.toLocaleString({ timeStyle: "short" }) : date.toRelative()}
+            </Typography>
+            <Typography variant="caption">
+              updated {DateTime.fromISO(beep.pick_up_eta_updated_at!).toRelative()}
+            </Typography>
+          </Stack>
+        );
+      })() : (
         <Typography>N/A</Typography>
       )
     },

--- a/website/src/routes/admin/beeps/$beepId.tsx
+++ b/website/src/routes/admin/beeps/$beepId.tsx
@@ -8,7 +8,6 @@ import { Marker as BeeperMarker } from "../../../components/Marker";
 import { DeleteBeepDialog } from "../../../components/DeleteBeepDialog";
 import {
   createFileRoute,
-  createRoute,
   useRouter,
 } from "@tanstack/react-router";
 import { useTRPC } from "../../../utils/trpc";
@@ -159,6 +158,26 @@ function Beep() {
             .rescale()
             .toHuman()
         : "N/A",
+    },
+    {
+      title: "ETA",
+      content: beep.eta ? (
+        <Typography>
+          {DateTime.fromISO(beep.eta).toRelative()}
+        </Typography>
+      ) : (
+        <Typography>N/A</Typography>
+      )
+    },
+    {
+      title: "ETA updated",
+      content: beep.eta_updated_at ? (
+        <Typography>
+          {DateTime.fromISO(beep.eta_updated_at).toRelative()}
+        </Typography>
+      ) : (
+        <Typography>N/A</Typography>
+      )
     },
   ];
 

--- a/website/src/routes/admin/users/$userId/ride.tsx
+++ b/website/src/routes/admin/users/$userId/ride.tsx
@@ -5,7 +5,7 @@ import { createFileRoute, useParams } from "@tanstack/react-router";
 import { useTRPC } from "../../../../utils/trpc";
 import { Loading } from "../../../../components/Loading";
 import { useSubscription } from "@trpc/tanstack-react-query";
-import { keepPreviousData, skipToken, useQuery } from "@tanstack/react-query";
+import { keepPreviousData, skipToken, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Marker as BeeperMarker } from "../../../../components/Marker";
 import { Layer, Marker, Source } from "react-map-gl/maplibre";
 import { BasicUser } from "../../../../components/BasicUser";
@@ -27,11 +27,26 @@ export const Route = createFileRoute("/admin/users/$userId/ride")({
 function Ride() {
   const trpc = useTRPC();
   const theme = useTheme();
+  const queryClient = useQueryClient();
 
   const { userId } = useParams({ from: Route.id });
 
-  const { data: ride, error } = useSubscription(
-    trpc.rider.currentRideUpdates.subscriptionOptions(userId),
+  const { data: ride, isLoading, error } = useQuery(trpc.rider.currentRide.queryOptions(userId));
+
+  useSubscription(
+    trpc.rider.currentRideUpdates.subscriptionOptions(userId, {
+      onData(data) {
+        queryClient.setQueryData(trpc.rider.currentRide.queryKey(userId), (prev) => {
+          if (data === null) {
+            return null;
+          }
+          if (!prev) {
+            return data as typeof ride;
+          }
+          return { ...prev, ...data };
+        });
+      }
+    }),
   );
 
   const { data: rider } = useSubscription(
@@ -74,7 +89,7 @@ function Ride() {
     lng: route.waypoints[1].location[0],
   };
 
-  if (ride === undefined) {
+  if (isLoading) {
     return <Loading />;
   }
 


### PR DESCRIPTION
### Architecture

#### The Goal

- Decouple the car movement from the ETA calculation

#### Current

Currently, ETAs are calculated when the rider's device request it. Rider devices request the ETA whenever they get a location update from the driver **and** the app is in the foreground. I just stream driver location updates to the rider as they come in, without any throttling/debouncing, causing the riders device to make frequent ETA calls to the API, which reaches out to OSRM. This means: frequent requests to the OSRM service happen if the rider has the app open and they are watching the ETA change. 

#### Proposed

Rather than calculating ETAs "on demand" when the rider's device requests it, we could have the backend API calculate ETAs every so often when the driver's device sends a location update and store those ETAs in the database.

To accomplish this, we'd add a new `pick_up_eta` column and `pick_up_eta_updated_at` column to the "ride" table in the database. `pick_up_eta` holds a timestamp of when the driver is expected to arrive. `pick_up_eta_updated_at` holds when `pick_up_eta` was last updated. Whenever the driver's device sends a location update, we can lookup when the ride's ETA was last updated, and if it's been >= ~30 seconds since the ETA was last calculated, we can recalculate the ETA using the OSRM service. 

Making this architectural change will make it easier to provide ETAs in live activities. It will also make it possible for admins to see the same ETAs riders see.

One downside of this approach is that every time a driver's device sends a location update, the backend API will do a lookup in the database to see if it needs to recalculate a new ETA. I expect this will create more load on the database but it may reduce OSRM load because the backend will inherently "throttle" how often it recalculates the ETA. 