### PR TITLE
chore(ci): Fix pnpm broken in CI (use pnpm 11.10.0)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -24,7 +24,7 @@ jobs:
           bun-version: latest
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: 11.10.0
           run_install: false
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -23,7 +23,7 @@ jobs:
           bun-version: latest
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: 11.10.0
           run_install: false
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -24,7 +24,7 @@ jobs:
           bun-version: latest
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: 11.10.0
           run_install: false
       - uses: actions/setup-node@v6
         with:
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: 11.10.0
           run_install: false
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Kind of crazy that pnpm just broke being pinned to the latest version...

Pinning to 11.10.0 for now...

https://github.com/pnpm/action-setup/issues/276